### PR TITLE
Load State, Update #28

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -55,6 +55,8 @@ CLI.prototype._createInstance = function () {
 
   self.screen.key(['escape'], function (ch, key) {
     self.screen.destroy();
+    // console.log('the machine:', self.oracle.machine);
+    // console.log('the mempool:', self.oracle.mempool);
     process.exit();
   });
 };
@@ -218,6 +220,8 @@ CLI.prototype.start = async function () {
     created: finish.toISOString(),
     input: `Historical context loaded in ${finish - start}ms.  Welcome!`
   });
+
+  // self.oracle.subscribe('/');
 
   // self.form.focus();
   self.textbox.readInput();

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -151,13 +151,12 @@ CLI.prototype._assembleInterface = function () {
 
   self.form.on('submit', async function (data) {
     let now = new Date();
+
+    // TODO: visual indicator of "sending..." status
     let result = await self.oracle._POST('/messages', {
       created: now.toISOString(),
       input: data.input
     });
-
-    // TODO: rely on datastore to trigger append
-    //self._appendMessage(result);
 
     self.form.reset();
     self.screen.render();
@@ -174,13 +173,32 @@ CLI.prototype._appendMessage = function (message) {
 
   self.history.pushLine(`${instance.created}${(instance.actor) ? ' ' + instance.actor : ''}: ${instance.input}`);
   self.history.setScrollPerc(100);
+
+  self.screen.render();
 };
 
 CLI.prototype.handler = function (msg) {
-  var self = this;
-  console.log('[CLI]', 'received message from oracle:', msg);
-  if(self._appendMessage && self.history){
-      self._appendMessage(msg);
+  let self = this;
+
+  // console.log('[CLI]', 'received change event from oracle:', msg);
+  // console.log('[CLI]', 'state is currently:', this.oracle.machine.state);
+
+  for (let i = 0; i < msg.length; i++) {
+    let instruction = msg[i];
+    // TODO: receive events from collection
+    // we should (probably) use Proxy() for this
+    switch (instruction.path.split('/')[1]) {
+      // TODO: fix Machine bug; only one delta should be emitted;
+      case 'messages':
+        // TODO: eliminate need for this check
+        // on startup, the Oracle emits a `changes` event with a full state
+        // snapshot... this might be useful overall, but the CLI (Chat) should
+        // either rely on this exclusively or not at all
+        if (self.history) {
+          self._appendMessage(instruction.value);
+        }
+        break;
+    }
   }
 };
 

--- a/lib/http.js
+++ b/lib/http.js
@@ -98,7 +98,11 @@ class HTTP extends Oracle {
       let resource = this.resources[name];
       // TODO: specify loading cases
       let result = await this._GET(resource.routes.list);
-      this.machine.state[resource.routes.list] = result;
+      this.machine.applyOperation({
+        op: 'add',
+        path: resource.routes.list,
+        value: result
+      });
     }
 
     try {

--- a/lib/oracle.js
+++ b/lib/oracle.js
@@ -147,7 +147,7 @@ Oracle.prototype._PUT = async function (key, obj) {
   try {
     this.machine.applyOperation(op);
   } catch (E) {
-    console.log('error apply operation:', E);
+    console.log('error applying operation:', E);
   }
 
   this.machine.commit();
@@ -198,8 +198,6 @@ Oracle.prototype._POST = async function (key, obj) {
   } catch (E) {
     console.debug(E);
   }
-
-  this.emit('changes', result);
 
   return result;
 };

--- a/lib/oracle.js
+++ b/lib/oracle.js
@@ -42,6 +42,10 @@ class Oracle extends Vector {
 
     this.machine.on('changes', this._handler.bind(this));
 
+    // TODO: pre-populate
+    // this.state = await this._GET('/');
+    // console.log('state retrieved:', this.state);
+
     return this;
   }
 
@@ -181,6 +185,7 @@ Oracle.prototype._POST = async function (key, obj) {
   try {
     let id = key + '/' + vector['@id'];
 
+    // update indexes
     this.keys.push(vector['@id']);
     this.keys.push(key);
     this.keys.push(id);

--- a/lib/oracle.js
+++ b/lib/oracle.js
@@ -105,6 +105,24 @@ Oracle.prototype._load = async function bootstrap (dir) {
   return response;
 };
 
+/**
+ * Creates and stores a detached object, without placing it into a collection.
+ * @param  {Object} obj Instance of the object to store.
+ * @return {Vector}     Returned from `storage.set`
+ */
+Oracle.prototype._CREATE = async function (obj) {
+  let result = null;
+  let vector = new Fabric.Vector(obj)._sign();
+
+  try {
+    result = await this.storage.set(vector.id, obj);
+  } catch (E) {
+    console.error('Error creating object:', E, obj);
+  }
+
+  return result;
+};
+
 Oracle.prototype._GET = async function (key, params) {
   let result = null;
 
@@ -119,11 +137,23 @@ Oracle.prototype._GET = async function (key, params) {
 
 Oracle.prototype._PUT = async function (key, obj) {
   let output = null;
+  // TODO: consider enforcing `/` as prefix?
+  let op = { op: 'add', path: key, value: obj };
+
+  try {
+    this.machine.applyOperation(op);
+  } catch (E) {
+    console.log('error apply operation:', E);
+  }
+
+  this.machine.commit();
 
   try {
     let vector = new Vector(obj)._sign();
     let result = await this.storage.set(key, vector['@data']);
-    output = await this._GET(key);
+    if (result) {
+      output = await this._GET(key);
+    }
   } catch (E) {
     console.error('[ORACLE]', '_PUT', E);
   }
@@ -150,12 +180,16 @@ Oracle.prototype._POST = async function (key, obj) {
 
   try {
     let id = key + '/' + vector['@id'];
-    let index = await this._PUT(key, collection);
 
+    this.keys.push(vector['@id']);
     this.keys.push(key);
     this.keys.push(id);
 
-    result = await this._PUT(id, vector['@data']);
+    let instance = await this._CREATE(obj);
+    let item = await this._PUT(id, vector['@data']);
+    let index = await this._PUT(key, collection);
+
+    result = item;
   } catch (E) {
     console.debug(E);
   }


### PR DESCRIPTION
This cleans up the Machine instance to hold a normalized state object, i.e., `messages` for the list of messages, etc. — when accessed over HTTP, path is still prefixed with `/`, so `messages` ⇒ `/messages`

This updates martindale/fabric#28 to be ready for merging.